### PR TITLE
Make synced folder relative in Vagrantfile

### DIFF
--- a/files/vagrant/Vagrantfile
+++ b/files/vagrant/Vagrantfile
@@ -43,7 +43,7 @@ Vagrant.configure("2") do |config|
   # the path on the host to the actual folder. The second argument is
   # the path on the guest to mount the folder. And the optional third
   # argument is a set of non-required options.
-  config.vm.synced_folder "C:/Projects/pharinix", "/var/www/html"
+  config.vm.synced_folder "./../../", "/var/www/html"
 
   # Provider-specific configuration so you can fine-tune various
   # backing providers for Vagrant. These expose provider-specific options.


### PR DESCRIPTION
In Vagrantfile you can use relative routes to accept "vagrant up" directly in your "files/vagrant" directory. Useful if you want to execute "vagrant up" inside "/pharinix/files/vagrant".